### PR TITLE
Added col_min_size and col_step_size options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Grid Editor
 
 Grid Editor is a visual javascript editor for the [bootstrap grid system](http://getbootstrap.com/css/#grid), written as a [jQuery](http://jquery.com/) plugin.
 
-![Preview](http://i.imgur.com/UF9CCzk.png) 
+![Preview](http://i.imgur.com/UF9CCzk.png)
 
 # <a href="http://transfer.frontwise.com/frontwise/grid-editor/example/" target="_blank">Try the demo!</a>
 
@@ -11,7 +11,7 @@ Installation
 ------------
 
 * __Dependencies:__ Grid Editor depens on jQuery, jQuery UI, and Bootstap, so make sure you have included those in the page. If you want to use the tincyMCE integration, load tinyMCE en tinyMCE jQuery plugin as well.
-* [Download the latest version of Grid Editor](https://github.com/Frontwise/grid-editor/archive/master.zip) and include it in your page: 
+* [Download the latest version of Grid Editor](https://github.com/Frontwise/grid-editor/archive/master.zip) and include it in your page:
 
 ```html
 <!-- Make sure jQuery, jQuery UI, and bootstrap 3 are included. TinyMCE is optional. -->
@@ -26,7 +26,7 @@ $('#myGrid').gridEditor({
     new_row_layouts: [[12], [6,6], [9,3]],
 });
 ```
-    
+
 Options
 -------
 
@@ -55,7 +55,7 @@ $('#myGrid').gridEditor({
     row_tools: [{
         title: 'Set background image',
         iconClass: 'glyphicon-picture',
-        on: { 
+        on: {
             click: function() {
                 $(this).closest('.row').css('background-image', 'url(http://placekitten.com/g/300/300)');
             }
@@ -63,8 +63,12 @@ $('#myGrid').gridEditor({
     }]
 });
 ```
-    
+
 __`col_tools`:__ the same as row_tools, but for columns.
+
+__`col_min_size`:__ minimal size of a column (1-12)
+
+__`col_stop_size`:__ steps when resizing a column (1-12)
 
 Attribution
 -----------

--- a/src/js/jquery.grideditor.js
+++ b/src/js/jquery.grideditor.js
@@ -22,6 +22,8 @@ $.fn.gridEditor = function( options ) {
                                     [4, 8],
                                     [8, 4]
                                 ],
+            'col_min_size'      : 1,
+            'col_step_size'     : 1,
             'row_classes'       : [{ label: 'Example class', cssClass: 'example-class'}],
             'col_classes'       : [{ label: 'Example class', cssClass: 'example-class'}],
             'col_tools'         : [], /* Example:
@@ -43,6 +45,7 @@ $.fn.gridEditor = function( options ) {
         ;
         var colClasses = ['col-md-', 'col-sm-', 'col-xs-'];
         var curColClassIndex = 0; // Index of the column class we are manipulating currently
+        var MIN_COL_SIZE = settings.col_min_size;
         var MAX_COL_SIZE = 12;
 
         setup();
@@ -238,18 +241,17 @@ $.fn.gridEditor = function( options ) {
 
                 createTool(drawer, 'Move', 'ge-move', 'glyphicon-move');
 
-                createTool(drawer, 'Make column narrower\n(hold shift for min)', 'ge-decrease-col-width', 'glyphicon-minus', function(e) {
-                    var curColClass = colClasses[curColClassIndex];
-                    var newSize = getColSize(col, curColClass) - 1;
-                    if (e.shiftKey) {
-                        newSize = 1;
+                createTool(drawer, 'Make column narrower\n(hold shift for min)', 'ge-decrease-col-width', 'glyphicon-minus', function(e) {                    var curColClass = colClasses[curColClassIndex];
+                    var newSize = getColSize(col, curColClass) - settings.col_step_size;
+                    if (e.shiftKey || newSize < MIN_COL_SIZE) {
+                        newSize = MIN_COL_SIZE;
                     }
                     setColSize(col, curColClass, Math.max(newSize, 1));
                 });
 
                 createTool(drawer, 'Make column wider\n(hold shift for max)', 'ge-increase-col-width', 'glyphicon-plus', function(e) {
                     var curColClass = colClasses[curColClassIndex];
-                    var newSize = getColSize(col, curColClass) + 1;
+                    var newSize = getColSize(col, curColClass) + settings.col_step_size;
                     if (e.shiftKey) {
                         newSize = MAX_COL_SIZE;
                     }
@@ -259,7 +261,7 @@ $.fn.gridEditor = function( options ) {
                 createTool(drawer, 'Settings', '', 'glyphicon-cog', function() {
                     details.toggle();
                 });
-                
+
                 settings.col_tools.forEach(function(t) {
                     createTool(drawer, t.title || '', t.className || '', t.iconClass || 'glyphicon-wrench', t.on);
                 });
@@ -469,7 +471,7 @@ $.fn.gridEditor = function( options ) {
                 canvas.toggleClass(cssClass, i == colClassIndex);
             });
         }
-        
+
         function getRTE(type) {
             return $.fn.gridEditor.RTEs[type];
         }


### PR DESCRIPTION
This PR adds the options `col_min_size` and `col_step_size` to this plugin.

**col_min_size** allows to define a minimum value for columns (i.e. 3)
**col_step_size** defines a step size when resizing a column with the +/- buttons (i.e. 3)

With this two options, it is possible to limit the grid to certain specifications (i.e. 4 columns)
