### PR TITLE
Font Awesome CSS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ $('#myGrid').gridEditor({
 });
 ```
 
+Font Awesome
+------------
+
+Grid Editor can easily be used with [Font Awesome](http://fontawesome.io) by including `dist/grideditor-font-awesome.css`. Note that Font Awesome (min. version 4.0) has to be included before this stylesheet.
+
+
 Attribution
 -----------
 

--- a/src/less/grideditor-font-awesome.less
+++ b/src/less/grideditor-font-awesome.less
@@ -1,0 +1,44 @@
+/* Font Awesome Integration for Grid Editor
+ * (min. Version 4.0)
+ */
+.ge-canvas.ge-editing .ge-tools-drawer > a {
+	padding: 3px 5px;
+}
+.ge-canvas .glyphicon,
+.ge-mainControls .glyphicon {
+	top: 0;
+	display: inline-block;
+	font: normal normal normal 14px/1 FontAwesome;
+	font-size: inherit;
+	text-rendering: auto;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+.ge-canvas .glyphicon-move:before {
+	content: "\f047";
+}
+.ge-canvas .glyphicon-minus:before {
+	content: "\f147";
+}
+.ge-canvas .glyphicon-plus:before {
+	content: "\f196";
+}
+.ge-canvas .glyphicon-cog:before {
+	content: "\f013";
+}
+.ge-canvas .glyphicon-trash:before {
+	content: "\f014";
+}
+.ge-canvas .glyphicon-plus-sign:before,
+.ge-mainControls .glyphicon-plus-sign:before {
+	content: "\f055";
+}
+.ge-mainControls .glyphicon-eye-open:before {
+	content: "\f06e";
+}
+.ge-mainControls .glyphicon-chevron-left:before {
+	content: "\f121";
+}
+.ge-mainControls .glyphicon-chevron-right {
+	display: none;
+}


### PR DESCRIPTION
As proposed in #9, this PR adds `gridmanager-font-awesome.less` to grid editor (See README for further information).

I put it in as `.less` file, so it would be integrated into the existing grunt workflow. Not sure, if this is the best idea, but it works. @Epskampie Let me know, if you'f also like to have an example in the `example/` folder.

![grid-editor_font-awesome](https://cloud.githubusercontent.com/assets/343392/10972180/64e4fb54-83d8-11e5-98d3-976a09eca1ef.png)
