### PR TITLE
Fixed a bug that prevented rows in columns from being moved

### DIFF
--- a/src/js/jquery.grideditor.js
+++ b/src/js/jquery.grideditor.js
@@ -489,7 +489,7 @@ $.fn.gridEditor = function( options ) {
             });
             canvas.add(canvas.find('.column')).sortable({
                 items: '> .row, > .ge-content',
-                connectsWith: '.ge-canvas, .ge-canvas .column',
+                connectWith: '.ge-canvas, .ge-canvas .column',
                 handle: '> .ge-tools-drawer .ge-move',
                 start: sortStart,
                 helper: 'clone',


### PR DESCRIPTION
Fixed a bug that prevented rows in columns from being moved, and also prevented single rows from being moved within columns.

This was a spelling error. Simply replace connectsWith with connectWith